### PR TITLE
Fix broken link to nohello

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@
       <em>"How do I do [problem] with Java and [other relevant info]?"</em>
     </p>
     <p>
-      Other similar problems: <a href="http://xyproblem.info/">The XY Problem</a>, <a href="http://nohello.com/">No Hello</a>.
+      Other similar problems: <a href="http://xyproblem.info/">The XY Problem</a>, <a href="https://www.nohello.com/">No Hello</a>.
       Further reading: <a href="https://stackoverflow.com/help/how-to-ask">How do I ask a good question?</a>,
       or if you have more time: <a href="http://catb.org/~esr/faqs/smart-questions.html">How To Ask Questions The Smart Way</a>.
     </p>


### PR DESCRIPTION
Not sure if some browsers are supposed to automatically add the www subdomain, but on my end accessing http://nohello.com brings me to an error page.