### PR TITLE
Add automatic dark theme for dark mode users

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,3 +1,4 @@
+/* -*- css-indent-offset: 2; -*- */
 :root {
   --light:                    #FAFAFA;
   --lighter:                  #CCC;


### PR DESCRIPTION
This PR adds an automatic dark theme for dark mode users through the
usage of a media query. It attempts to keep the spirit of the original
theme.

It also adds the usage of CSS variables to make the code more
maintainable, as well as a file variable for Emacs users so Emacs
doesn’t change the indentation that is already used (mine tried to use
four spaces by default).

Just in case, I also created a Nord themed version of this fork you
can find
[here](https://github.com/Phundrak/dontasktoask.com/tree/feature/nord-theme),
I can create a new PR for it if you want (otherwise I’ll simply use
this theme with Stylus).