### PR TITLE
pt-br: Link to recommended pt-br translation

### DIFF
--- a/pt-br/index.html
+++ b/pt-br/index.html
@@ -79,7 +79,7 @@
     <p>
       Outros problemas similares: <a href="https://xyproblem.info/">O problema XY</a>, <a href="https://nohello.net/">Não diga olá</a>.
       Leitura aprofundada: <a href="https://stackoverflow.com/help/how-to-ask">Como eu posso fazer uma boa pergunta?</a>,
-      ou se você tem mais tempo: <a href="http://catb.org/~esr/faqs/smart-questions.html">O jeito inteligente de fazer perguntas</a>.
+      ou se você tem mais tempo: <a href="https://www.homeyou.com/~edu/perguntar-de-forma-inteligente">Como Perguntar de Forma Inteligente</a>.
     </p>
   </main>
   <footer>


### PR DESCRIPTION
The [How To Ask Questions The Smart Way](http://catb.org/~esr/faqs/smart-questions.html) page links to some [translations](http://catb.org/~esr/faqs/smart-questions.html#translations), including pt-br. So how about use it instead?

@danarrib What do you say?