### PR TITLE
Fixed pt-br typos

### DIFF
--- a/pt-br/index.html
+++ b/pt-br/index.html
@@ -17,7 +17,7 @@
     <h1>Não peça para perguntar, apenas pergunte</h1>
     <p>
       De vez em quando, nas salas de bate papo online em que eu participo, aparece
-      alguém falando algo parecido com,
+      alguém falando algo parecido com:
     </p>
     <blockquote>
       <span class="name">Foobar123:</span>
@@ -27,12 +27,12 @@
     </blockquote>
     <p>
       Esse é um jeito ruim, por vários motivos. O que a pessoa está
-      <em>realmente</em> perguntando é,
+      <em>realmente</em> perguntando é:
     </p>
     <blockquote>
       <span class="name">Foobar123:</span>
       <p class="message">
-        Alguém por aí que entende está disposto a se comprometer a olhar o meu
+        Alguém por aí que entende de Java está disposto a se comprometer a olhar o meu
         problema, qualquer ele que seja, mesmo se ele não for exatamente relacionado
         com Java ou mesmo se alguém que não sabe nada de Java puder
         responder a minha pergunta?
@@ -66,7 +66,7 @@
     </p>
     <p>
       A solução é não pedir para perguntar, mas simplesmente perguntar. Alguém que 
-      esteja oscioso no canal e apenas de vez em quando aparece para ver o que está acontecendo
+      esteja ocioso no canal e apenas de vez em quando aparece para ver o que está acontecendo
       dificilmente vai responder ao seu "pedido de pergunta", mas a descrição do seu
       problema real talvez desperte o interesse e ele dedique algum tempo para responder.
     </p>


### PR DESCRIPTION
- The first "Java" is missing from the first quoteblock;
- The word "ocioso" is spelled wrong ("oscioso");
- Also I've replaced two commas with colons because we use that before citations.